### PR TITLE
Fixes to README.md in single commit for PhoneGap 1.3 changes, (lib)sqlite, and using subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ We are brand new to objective-c, so there could be problems with our code!
 Installing
 ==========
 
+PhoneGap 1.3.0
+--------------
+
 For installing with PhoneGap 1.3.0:
 in PGSQLitePlugin.h file change for PhoneGaps JSONKit.h implementation.
 
@@ -24,11 +27,28 @@ in PGSQLitePlugin.h file change for PhoneGaps JSONKit.h implementation.
         #import "File.h"
     #endif
 
-In the Project Build Phases tab, select the "Link Binary with Libraries" dropdown menu and add 2 libraries:
+and in PGSQLitePlugin.m JSONRepresentation must be changed to JSONString:
 
-libsqlite3.0.dylib
-libsqlite3.dylib
+    --- a/Plugins/PGSQLitePlugin.m
+    +++ b/Plugins/PGSQLitePlugin.m
+    @@ -219,7 +219,7 @@
+             if (hasInsertId) {
+                 [resultSet setObject:insertId forKey:@"insertId"];
+             }
+    -        [self respond:callback withString:[resultSet JSONRepresentation] withType:@"success"];
+    +        [self respond:callback withString:[resultSet JSONString] withType:@"success"];
+         }
+     }
 
+SQLite library
+--------------
+
+In the Project "Build Phases" tab, select the _first_ "Link Binary with Libraries" dropdown menu and add the library `libsqlite3.dylib` or `libsqlite3.0.dylib`.
+
+**NOTE:** In the "Build Phases" there can be multiple "Link Binary with Libraries" dropdown menus. Please select the first one otherwise it will not work.
+
+PGSQLite Plugin
+---------------
 
 Drag .h and .m files into your project's Plugins folder (in xcode) -- I always
 just have "Create references" as the option selected.


### PR DESCRIPTION
Please bear with me, this is my first time using github. I made a new fork and submit my changes to README.md in a single commit. Next time I will not push into master before I am more confident whether or not the patch will be accepted.

For PhoneGap 1.3, as I said before there is a change to Plugins/PGSQLitePlugin.m for the new JSONKit API. For 1.5 which is now Cordova they have changed the API. I tried porting this plugin to Cordova but it did not work and I do not have time right now to debug what is going wrong. Someone has already raised [#14](https://github.com/davibe/Phonegap-SQLitePlugin/issues/14) to port to Cordova and I am happy to work on this issue after a few weeks.

There are some other enhancements to improve the documentation on using the libsqlite and also adding subsections to the Installing section. I hope you will be happy with these changes.
