### PR TITLE
Change of PhoneGap SQLitePlugin API to be closer to the W3 SQL API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ all: coffee
 
 coffee:
 	mkdir -p build
-	coffee -p src/pgsqlite_plugin.js.coffee > build/pgsqlite_plugin.js
-	coffee -p src/lawnchair_pgsqlite_plugin_adapter.js.coffee > build/lawnchair_pgsqlite_plugin_adapter.js
+	coffee -p src/pgsqlite_plugin.coffee > build/pgsqlite_plugin.js
+	coffee -p src/lawnchair_pgsqlite_plugin_adapter.coffee > build/lawnchair_pgsqlite_plugin_adapter.js
 
 clean:
 	rm -f build/pgsqlite_plugin.js

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ General Usage
     db.executeSql('DROP TABLE IF EXISTS test_table');
     db.executeSql('CREATE TABLE IF NOT EXISTS test_table (id integer primary key, data text, data_num integer)');
     db.transaction(function(tx) {
-      return tx.executeSql(["INSERT INTO test_table (data, data_num) VALUES (?,?)", "test", 100], function(res) {
+      return tx.executeSql("INSERT INTO test_table (data, data_num) VALUES (?,?)", ["test", 100], function(res) {
         console.log("insertId: " + res.insertId + " -- probably 1");
         console.log("rowsAffected: " + res.rowsAffected + " -- should be 1");
-        return db.executeSql("select count(id) as cnt from test_table;", function(res) {
+        return db.executeSql("select count(id) as cnt from test_table;", [], function(res) {
           console.log("rows.length: " + res.rows.length + " -- should be 1");
           return console.log("rows[0].cnt: " + res.rows[0].cnt + " -- should be 1");
         });

--- a/build/lawnchair_pgsqlite_plugin_adapter.js
+++ b/build/lawnchair_pgsqlite_plugin_adapter.js
@@ -1,4 +1,3 @@
-
 /*
      PGSQLitePlugin Lawnchair Adapter
      (c) 2011 Joe Noon <joenoon@gmail.com>
@@ -32,7 +31,7 @@
       };
       db = options.db || this.name;
       this.db = new PGSQLitePlugin("" + db + ".sqlite3");
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
     },
     keys: function(callback) {
       var cb, sql, success, that;
@@ -42,7 +41,7 @@
       success = function(res) {
         cb.call(that, res.rows);
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     },
     save: function(obj, callback) {
@@ -62,7 +61,7 @@
         delete obj.key;
         val.unshift(JSON.stringify(obj));
         sql = exists ? up : ins;
-        db.executeSql([sql].concat(val), success, fail);
+        db.executeSql(sql, val, success, fail);
       });
       return this;
     },
@@ -117,7 +116,7 @@
             sql = obj.key in ids_hash ? up : ins;
             delete obj.key;
             val.unshift(JSON.stringify(obj));
-            t.executeSql([sql].concat(val), success, fail);
+            t.executeSql(sql, val, success, fail);
           };
           for (_k = 0, _len3 = objs.length; _k < _len3; _k++) {
             obj = objs[_k];
@@ -132,7 +131,7 @@
       };
       if (keys.length > 0) {
         exists_sql = ["SELECT id FROM " + this.name + " WHERE id IN (" + marks + ")"].concat(keys);
-        db.executeSql(exists_sql, exists_success);
+        db.executeSql(exists_sql, [], exists_success);
       } else {
         exists_success({
           rows: []
@@ -180,7 +179,7 @@
         if (!is_array) r = r[0];
         if (cb) that.lambda(cb).call(that, r);
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     },
     exists: function(key, cb) {
@@ -190,7 +189,7 @@
       success = function(res) {
         if (cb) that.fn("exists", cb).call(that, res.rows.length > 0);
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     },
     all: function(callback) {
@@ -218,7 +217,7 @@
         })();
         cb.call(that, r);
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     },
     remove: function(keyOrObj, cb) {
@@ -231,7 +230,7 @@
       success = function() {
         if (cb) that.lambda(cb).call(that);
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     },
     nuke: function(cb) {
@@ -243,7 +242,7 @@
         if (cb) that.lambda(cb).call(that);
         db.executeSql("VACUUM");
       };
-      this.db.executeSql(sql, success, fail);
+      this.db.executeSql(sql, [], success, fail);
       return this;
     }
   };

--- a/build/pgsqlite_plugin.js
+++ b/build/pgsqlite_plugin.js
@@ -59,11 +59,11 @@
       delete callbacks[ref];
     };
 
-    PGSQLitePlugin.prototype.executeSql = function(sql, success, error) {
+    PGSQLitePlugin.prototype.executeSql = function(sql, params, success, error) {
       var opts;
       if (!sql) throw new Error("Cannot executeSql without a query");
       opts = getOptions({
-        query: [].concat(sql || []),
+        query: [sql].concat(params || []),
         path: this.dbPath
       }, success, error);
       PhoneGap.exec("PGSQLitePlugin.backgroundExecuteSql", opts);
@@ -109,9 +109,9 @@
       this.executes = [];
     }
 
-    PGSQLitePluginTransaction.prototype.executeSql = function(sql, success, error) {
+    PGSQLitePluginTransaction.prototype.executeSql = function(sql, params, success, error) {
       this.executes.push(getOptions({
-        query: [].concat(sql || []),
+        query: [sql].concat(params || []),
         path: this.dbPath
       }, success, error));
     };

--- a/src/lawnchair_pgsqlite_plugin_adapter.coffee
+++ b/src/lawnchair_pgsqlite_plugin_adapter.coffee
@@ -26,7 +26,7 @@ pgsqlite_plugin =
     # open a connection and create the db if it doesn't exist
     db = options.db || @name
     @db = new PGSQLitePlugin("#{db}.sqlite3")
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     return
 
   keys: (callback) ->
@@ -36,7 +36,7 @@ pgsqlite_plugin =
     success = (res) ->
       cb.call(that, res.rows)
       return
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
   save: (obj, callback) ->
@@ -55,7 +55,7 @@ pgsqlite_plugin =
       delete obj.key
       val.unshift(JSON.stringify(obj))
       sql = if exists then up else ins
-      db.executeSql [ sql ].concat(val), success, fail
+      db.executeSql sql, val, success, fail
       return
     this
 
@@ -111,7 +111,7 @@ pgsqlite_plugin =
             sql = if obj.key of ids_hash then up else ins
             delete obj.key
             val.unshift(JSON.stringify(obj))
-            t.executeSql [ sql ].concat(val), success, fail
+            t.executeSql sql, val, success, fail
             return
         return
 
@@ -126,7 +126,7 @@ pgsqlite_plugin =
     if keys.length > 0
       # the case where there is at least one object with an existing key
       exists_sql = [ "SELECT id FROM #{@name} WHERE id IN (#{marks})" ].concat(keys)
-      db.executeSql exists_sql, exists_success
+      db.executeSql exists_sql, [], exists_success
     else
       # the case where every object is new, so we don't need to do a select query first
       exists_success({ rows: [] })
@@ -156,7 +156,7 @@ pgsqlite_plugin =
       that.lambda(cb).call(that, r) if cb
       return
 
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
   exists: (key, cb) ->
@@ -165,7 +165,7 @@ pgsqlite_plugin =
     success = (res) ->
       that.fn("exists", cb).call(that, res.rows.length > 0) if cb
       return
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
   all: (callback) ->
@@ -181,7 +181,7 @@ pgsqlite_plugin =
           obj
       cb.call(that, r)
       return
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
   remove: (keyOrObj, cb) ->
@@ -193,7 +193,7 @@ pgsqlite_plugin =
     success = () ->
       that.lambda(cb).call(that) if cb
       return
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
   nuke: (cb) ->
@@ -205,7 +205,7 @@ pgsqlite_plugin =
       # clean up the db
       db.executeSql "VACUUM"
       return
-    @db.executeSql sql, success, fail
+    @db.executeSql sql, [], success, fail
     this
 
 PGSQLitePlugin.lawnchair_adapter = pgsqlite_plugin

--- a/src/pgsqlite_plugin.coffee
+++ b/src/pgsqlite_plugin.coffee
@@ -48,9 +48,9 @@ class root.PGSQLitePlugin
     delete callbacks[ref]
     return
     
-  executeSql: (sql, success, error) ->
+  executeSql: (sql, params, success, error) ->
     throw new Error "Cannot executeSql without a query" unless sql
-    opts = getOptions({ query: [].concat(sql || []), path: @dbPath }, success, error)
+    opts = getOptions({ query: [sql].concat(params || []), path: @dbPath }, success, error)
     PhoneGap.exec("PGSQLitePlugin.backgroundExecuteSql", opts)
     return
 
@@ -78,8 +78,8 @@ class root.PGSQLitePluginTransaction
   constructor: (@dbPath) ->
     @executes = []
     
-  executeSql: (sql, success, error) ->
-    @executes.push getOptions({ query: [].concat(sql || []), path: @dbPath }, success, error)
+  executeSql: (sql, params, success, error) ->
+    @executes.push getOptions({ query: [sql].concat(params || []), path: @dbPath }, success, error)
     return
   
   complete: (success, error) ->


### PR DESCRIPTION
From [issue #11](https://github.com/davibe/Phonegap-SQLitePlugin/issues/11): it would be great to use almost the same API as the HTML5/W3 SQL API.

I hereby propose a couple small changes to the plugin in the executeSql() member function of the transaction object and the PGSQLitePlugin database object, so that the array of values is kept separate from the SQL string itself. This change makes the SQLitePlugin API closer to the HTML5/W3 SQL API.

This change would also make the application code more portable to the existing Android Storage plugin from: https://github.com/apache/incubator-cordova-android/blob/master/framework/src/org/apache/cordova/Storage.java

I made some changes to the lawnchair adapter but I did not have a chance to test them. Perhaps it would be better to put these changes together with the Cordova version.
