### PR TITLE
Insert ID bug

### DIFF
--- a/Plugins/PGSQLitePlugin.m
+++ b/Plugins/PGSQLitePlugin.m
@@ -196,10 +196,10 @@
                 diffRowsAffected = nowRowsAffected - previousRowsAffected;
                 rowsAffected = [NSNumber numberWithInt:diffRowsAffected];
                 nowInsertId = sqlite3_last_insert_rowid(db);
-                if (previousInsertId != nowInsertId) {
+                //if (previousInsertId != nowInsertId) {
                     hasInsertId = YES;
                     insertId = [NSNumber numberWithLongLong:sqlite3_last_insert_rowid(db)];
-                }
+                //}
                 keepGoing = NO;
                 break;
                 


### PR DESCRIPTION
I haven't touched this code in awhile but it was a big problem when i ran into it. If you have two fresh tables, and insert a new row in each, this will fail because they both generate the same id. It really needs to keep a dictionary/hash of the last insert id per table, vs. at a global level but I am too lazy to do that :)
